### PR TITLE
fix: bump Go to 1.25 and air

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # syntax=docker/dockerfile:1.7
 
-FROM golang:1.22-bookworm
+FROM golang:1.25-bookworm
 
 ARG BUF_VERSION=1.64.0
-ARG AIR_VERSION=1.61.7
+ARG AIR_VERSION=1.64.5
 ARG OAPI_CODEGEN_VERSION=2.4.1
 
 RUN apt-get update \

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ Go development container image for Agynio services.
 
 | Tool | Version (default) | Notes |
 | --- | --- | --- |
-| Go | 1.22 (golang:1.22-bookworm) | Base image |
+| Go | 1.25 (golang:1.25-bookworm) | Base image |
 | buf | 1.64.0 | Multi-arch binary via `BUF_VERSION` |
-| air | 1.61.7 | Go hot-reload via `AIR_VERSION` |
+| air | 1.64.5 | Go hot-reload via `AIR_VERSION` |
 | oapi-codegen | 2.4.1 | OpenAPI code generation via `OAPI_CODEGEN_VERSION` |
 | git, curl, bash, openssh-client, inotify-tools | Debian packages | Installed via apt |
 


### PR DESCRIPTION
## Summary
- bump Go base image to 1.25 in Dockerfile
- update air version to 1.64.5
- align README tooling versions

## Testing
- Not run (no tests configured)

## Lint
- Not run (no lint configuration)

Closes #3